### PR TITLE
Fix desktop icon layout and app launching

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ body { background-image: url('https://wallpaperaccess.com/full/317501.jpg'); bac
 <body class="h-screen w-screen overflow-hidden relative" id="desktop">
 <div id="navbar">Chantelini soluciones SA <img src="https://img.icons8.com/ios-filled/24/mac-os.png" class="ml-auto"/></div>
 <!-- Icons -->
-<div id="icons" class="p-4 space-y-4">
+<div id="icons" class="p-4 flex flex-wrap gap-4">
   <div class="icon" data-app="db"><img src="https://img.icons8.com/fluency/96/000000/database.png"/><p>Base Datos</p></div>
   <div class="icon" data-app="mail"><img src="https://img.icons8.com/fluency/96/000000/apple-mail.png"/><p>Correo</p></div>
   <div class="icon" data-app="graph"><img src="https://img.icons8.com/fluency/96/000000/graph.png"/><p>Grafo</p></div>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,8 @@
 $(function(){
-  // make icons draggable
-  $(".icon").draggable({containment:'#desktop'});
+  // make icons draggable if jQuery UI is loaded
+  if($.fn.draggable){
+    $(".icon").draggable({containment:'#desktop'});
+  }
 
   let z=1;
     function createWindow(id,title,content){
@@ -14,7 +16,12 @@ $(function(){
       header.find('.min').on('click',()=>win.hide());
       header.find('.max').on('click',()=>win.toggleClass('fixed').toggleClass('absolute'));
       $('#windows').append(win);
-      win.draggable({handle:'.window-header'}).resizable({handles:'all',containment:'#desktop'});
+      if($.fn.draggable){
+        win.draggable({handle:'.window-header'});
+      }
+      if($.fn.resizable){
+        win.resizable({handles:'all',containment:'#desktop'});
+      }
     }
 
   function setSelected(el){


### PR DESCRIPTION
## Summary
- arrange icons from the top-left using a flex layout
- guard draggable/resizable features in case jQuery UI is missing

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685b2ff1eb408326b5f5860393766cc3